### PR TITLE
Python 3.8 compatibility, PROV-N export

### DIFF
--- a/rationai/provenance/data/tiler/xml_annot_patcher.py
+++ b/rationai/provenance/data/tiler/xml_annot_patcher.py
@@ -138,7 +138,9 @@ def export_provenance(log_fp: Path) -> None:
 
             # Folder Config Entity Node
             data_folder = flatten_lists(data_folder)
-            rawDataCfg = bndl.entity(f"{NAMESPACE_PREPROC}:Config {Path(data_folder['slide_dir']).name}", other_attributes=(global_cfg | data_folder))
+            _config = dict(global_cfg)
+            _config.update(data_folder)
+            rawDataCfg = bndl.entity(f"{NAMESPACE_PREPROC}:Config {Path(data_folder['slide_dir']).name}", other_attributes=(_config))
 
             # Folder Table Entity Node
             roiDataTable = bndl.entity(f"{NAMESPACE_PREPROC}:roiTables {Path(data_folder['slide_dir']).name}", other_attributes={})

--- a/rationai/provenance/data/tiler/xml_annot_patcher.py
+++ b/rationai/provenance/data/tiler/xml_annot_patcher.py
@@ -17,7 +17,7 @@ from rationai.provenance import NAMESPACE_TRAINING
 from rationai.provenance import prepare_document
 
 from rationai.utils.provenance import parse_log
-from rationai.utils.provenance import export_to_image
+from rationai.utils.provenance import export_to_image, export_to_provn
 from rationai.utils.provenance import flatten_lists
 from rationai.utils.provenance import get_sha256
 from rationai.utils.provenance import hash_tables_by_groups
@@ -161,7 +161,7 @@ def export_provenance(log_fp: Path) -> None:
     bndl.specialization(hdf_file, sendTestingConnEntDataset)
 
     export_to_image(bndl, 'preprocessing')
-
+    export_to_provn(doc, 'preprocessing')
 
 
 if __name__=='__main__':

--- a/rationai/provenance/experiments/slide_test_eval.py
+++ b/rationai/provenance/experiments/slide_test_eval.py
@@ -16,7 +16,7 @@ from rationai.provenance import NAMESPACE_TRAINING
 from rationai.provenance import prepare_document
 
 from rationai.utils.provenance import parse_log
-from rationai.utils.provenance import export_to_image
+from rationai.utils.provenance import export_to_image, export_to_provn
 from rationai.utils.provenance import get_sha256
 from rationai.utils.provenance import flatten_dict
 
@@ -158,6 +158,8 @@ def export_provenance(test_log_fp: Path, eval_log_fp: Path) -> None:
     bndl.wasGeneratedBy(testEvals, evalRun)
 
     export_to_image(bndl, 'evaluation')
+    export_to_provn(doc, 'evaluation')
+
 
 if __name__=='__main__':
     parser = argparse.ArgumentParser(description=__doc__,

--- a/rationai/provenance/experiments/slide_test_eval.py
+++ b/rationai/provenance/experiments/slide_test_eval.py
@@ -131,7 +131,8 @@ def export_provenance(test_log_fp: Path, eval_log_fp: Path) -> None:
     # Data Entities
     predict_file_attrs = {'filepath': log_t['predictions']['prediction_file'], 'sha256': get_sha256(log_t['predictions']['prediction_file'])}
     predict_table_hashes = log_t['predictions']['sha256']
-    testPredicts = bndl.entity(f"{NAMESPACE_EVAL}:testPredictions", other_attributes= predict_file_attrs | predict_table_hashes)
+    predict_file_attrs.update(predict_table_hashes)
+    testPredicts = bndl.entity(f"{NAMESPACE_EVAL}:testPredictions", other_attributes= predict_file_attrs)
     testEvals = bndl.entity(f"{NAMESPACE_EVAL}:testEvaluations", other_attributes=flatten_dict(log_e['eval']))
 
     # Input Data Specializations

--- a/rationai/provenance/experiments/slide_train.py
+++ b/rationai/provenance/experiments/slide_train.py
@@ -16,7 +16,7 @@ from rationai.provenance import NAMESPACE_TRAINING
 from rationai.provenance import prepare_document
 
 from rationai.utils.provenance import parse_log
-from rationai.utils.provenance import export_to_image
+from rationai.utils.provenance import export_to_image, export_to_provn
 from rationai.utils.provenance import get_sha256
 from rationai.utils.provenance import flatten_lists
 
@@ -204,8 +204,7 @@ def export_provenance(log_fp: Path) -> None:
         last_model = result_model
 
     export_to_image(bndl, 'training')
-
-
+    export_to_provn(doc, 'training')
 
 if __name__=='__main__':
     parser = argparse.ArgumentParser(description=__doc__,

--- a/rationai/provenance/experiments/slide_train.py
+++ b/rationai/provenance/experiments/slide_train.py
@@ -72,23 +72,23 @@ def export_provenance(log_fp: Path) -> None:
 
     has_part = 0
     if USE_VALIDATION:
-        other_attributes |= {f'{NAMESPACE_DCT}:hasPart{has_part}': f'{NAMESPACE_TRAINING}:datasetSplitting'}
+        other_attributes[f'{NAMESPACE_DCT}:hasPart{has_part}'] = f'{NAMESPACE_TRAINING}:datasetSplitting'
         has_part += 1
 
-    other_attributes |= {f'{NAMESPACE_DCT}:hasPart{has_part}': f'{NAMESPACE_TRAINING}:trainGenerator'}
+    other_attributes[f'{NAMESPACE_DCT}:hasPart{has_part}'] = f'{NAMESPACE_TRAINING}:trainGenerator'
     has_part += 1
 
     if USE_VALIDATION:
-         other_attributes |= {f'{NAMESPACE_DCT}:hasPart{has_part}': f'{NAMESPACE_TRAINING}:validGenerator'}
+         other_attributes[f'{NAMESPACE_DCT}:hasPart{has_part}'] = f'{NAMESPACE_TRAINING}:validGenerator'
          has_part += 1
 
     for iter_i in range(act_epochs):
-        other_attributes |= {f'{NAMESPACE_DCT}:hasPart{has_part}': f'{NAMESPACE_TRAINING}:trainIter{iter_i}'}
+        other_attributes[f'{NAMESPACE_DCT}:hasPart{has_part}'] = f'{NAMESPACE_TRAINING}:trainIter{iter_i}'
         has_part += 1
 
     if USE_VALIDATION:
         for iter_i in range(act_epochs):
-            other_attributes |= {f'{NAMESPACE_DCT}:hasPart{has_part}': f'{NAMESPACE_TRAINING}:validIter{iter_i}'}
+            other_attributes[f'{NAMESPACE_DCT}:hasPart{has_part}'] = f'{NAMESPACE_TRAINING}:validIter{iter_i}'
             has_part += 1
 
 

--- a/rationai/utils/provenance.py
+++ b/rationai/utils/provenance.py
@@ -217,8 +217,15 @@ def export_to_image(bundle: prov.model.ProvBundle, name: str) -> None:
         name: The name of the bundle as a string, given a suffix to the filename
               of the image.
     """
+    # FIXME: Configure which output directory
     dot = prov.dot.prov_to_dot(bundle)
     dot.write_png(f"prov-{name}.png")
+
+def export_to_provn(doc: prov.model.ProvDocument, name: str) -> None:
+    """Save bundle as a PROV-N document in current directory"""
+    # FIXME: Configure which output directory
+    with open(f"prov-{name}.provn", "w") as f:
+        doc.serialize(f, format="provn")
 
 def get_sha256(filepath: str, mock_env: bool = False) -> str:
     """Generate a SHA256 hash of a file with a given filename.

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,7 @@ pandas==1.4.2
 Pillow==9.1.0
 pip==21.2.4
 protobuf==3.20.0
+prov=2.0.0
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pygit2==1.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ pandas==1.4.2
 Pillow==9.1.0
 pip==21.2.4
 protobuf==3.20.0
-prov=2.0.0
+prov==2.0.0
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pygit2==1.9.1
@@ -48,7 +48,7 @@ requests==2.27.1
 requests-oauthlib==1.3.1
 rsa==4.8
 scikit-image==0.19.2
-scikit-learn==1.0.2
+scikit-learn==1.1.1
 scipy==1.8.0
 setuptools==58.1.0
 Shapely==1.8.1.post1
@@ -58,6 +58,7 @@ tensorboard==2.8.0
 tensorboard-data-server==0.6.1
 tensorboard-plugin-wit==1.8.1
 tensorflow==2.8.0
+tensorflow-gpu==2.8.0
 tensorflow-io-gcs-filesystem==0.24.0
 termcolor==1.1.0
 tf-estimator-nightly==2.8.0.dev2021122109


### PR DESCRIPTION
Fixes after working with Rudolf:

* Avoid `|=` dict syntax to keep Python 3.8 compatibility
* Explicit `prov` dependency
* conda-compatible version of `scikit-learn`
* Provenance: Export `*.provn` in addition to `*.png`
